### PR TITLE
cli - adds options to specifiy input and output file. adds help command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 dist
 types.ts
+typesx.ts
 generated-types.ts
+generated-typesx.ts
 TODO
 coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ts2typebox
 
-Cli tool to generate typebox types based on typescript types. Simple wrapper for
+Cli tool used to generate typebox types based on typescript types. Simple wrapper for
 the code from creator of [typebox](https://github.com/sinclairzx81/typebox),
 `Haydn Paterson (sinclair) <haydn.developer@gmail.com>`.
 
@@ -15,8 +15,12 @@ the code from creator of [typebox](https://github.com/sinclairzx81/typebox),
 
 ## Usage
 
-- You need a file containing your types in the current working directory that is
-  named `types.ts`. E.g.
+- The cli can be used with `ts2typebox --input <fileName> --output <fileName>`.
+  Can also be used by simply invoking `ts2typebox`. The input defaults to
+  "types.ts" and the output to "generated-types.ts" relative to the current
+  working directory.
+- Example: You need a file containing your types. E.g. `types.ts` in the current working
+  directory which could look like this:
 
 ```
 // Arbitrary example types
@@ -42,8 +46,8 @@ export type Person = {
 ```
 
 - Run `ts2typebox` to generate the according typebox types. The resulting file
-  is named `generated-types.ts` and is created in the current working directory.
-  The output would be:
+  will be named `generated-types.ts` and is created in the current working
+  directory. The output would look like this:
 
 ```
 import { Type, Static } from '@sinclair/typebox'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2typebox",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Create typebox types based on typescript types",
   "main": "dist/src/index.js",
   "source": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -40,17 +40,19 @@
   "dependencies": {
     "@sinclair/typebox": "0.26.8",
     "typescript": "5.0.2",
-    "prettier": "2.8.4"
+    "prettier": "2.8.4",
+    "minimist": "^1.2.8"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",
     "@babel/preset-env": "7.20.2",
     "@babel/preset-typescript": "7.18.6",
-    "@types/node": "18.15.3",
     "@types/jest": "29.4.0",
-    "jest": "29.4.1",
+    "@types/minimist": "^1.2.2",
+    "@types/node": "18.15.3",
     "babel-jest": "29.4.1",
     "babel-plugin-module-resolver": "4.1.0",
+    "jest": "29.4.1",
     "ts-node": "10.9.1",
     "tsconfig-paths": "4.1.2"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,9 @@ const main = () => {
     -o, --output
        Specifies the relative path to generated file that will contain the
        typebox types. Defaults to "generated-types.ts".
+
+    --output-stdout
+       Does not generate an output file and prints the generated code to stdout instead.
       `);
     process.exit(0);
   }
@@ -51,9 +54,16 @@ const main = () => {
   const resultFormatted = prettier.format(result, {
     parser: "typescript",
   });
+
+  if (args["output-stdout"]) {
+    console.log(resultFormatted);
+    process.exit(0);
+  }
+
   fs.writeFileSync(process.cwd() + `/${args.output}`, resultFormatted, {
     encoding: "utf8",
   });
+  process.exit(0);
 };
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,57 @@
 #!/usr/bin/env node
 import fs from "fs";
+import minimist from "minimist";
+import * as prettier from "prettier";
+
 import { TypeScriptToTypeBox } from "./typescript-to-typebox";
 
 const main = () => {
-  const fileWithTsTypes = fs.readFileSync(process.cwd() + "/types.ts", "utf8");
+  const args = minimist(process.argv.slice(2), {
+    alias: {
+      input: "i",
+      output: "o",
+      help: "h",
+    },
+    default: {
+      input: "types.ts",
+      output: "generated-types.ts",
+    },
+  });
 
+  if (args.help) {
+    console.log(`
+    ts2typebox is a cli tool to generate typebox types based on typescript
+    types. Version: ${process.env.npm_package_version}
+
+    Usage:
+
+    ts2typebox [ARGUMENTS]
+
+    Arguments:
+
+    -h, --help
+       Displays this menu.
+
+    -i, --input
+       Specifies the relative path to the file containing the typescript types
+       that will be used to generated typebox types. Defaults to "types.ts".
+
+    -o, --output
+       Specifies the relative path to generated file that will contain the
+       typebox types. Defaults to "generated-types.ts".
+      `);
+    process.exit(0);
+  }
+
+  const fileWithTsTypes = fs.readFileSync(
+    process.cwd() + `/${args.input}`,
+    "utf8"
+  );
   const result = TypeScriptToTypeBox.Generate(fileWithTsTypes);
-
-  fs.writeFileSync(process.cwd() + "/generated-types.ts", result, {
+  const resultFormatted = prettier.format(result, {
+    parser: "typescript",
+  });
+  fs.writeFileSync(process.cwd() + `/${args.output}`, resultFormatted, {
     encoding: "utf8",
   });
 };

--- a/src/typescript-to-typebox.ts
+++ b/src/typescript-to-typebox.ts
@@ -19,7 +19,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
-import * as prettier from "prettier";
 import * as ts from "typescript";
 
 // --------------------------------------------------------------------------
@@ -611,8 +610,6 @@ export namespace TypeScriptToTypeBox {
     }
     const imports = importStatments.join("\n");
 
-    return prettier.format(imports + "\n\n" + typeDeclarations, {
-      parser: "typescript",
-    });
+    return imports + "\n\n" + typeDeclarations;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,6 +1357,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/node@*":
   version "18.15.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
@@ -2564,7 +2569,7 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.6:
+minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==


### PR DESCRIPTION
## How to test

- help text should display: `yarn build && yarn start -h`
- should print generated output to stdout: `yarn build && yarn start --output-stdout`
- should use file with different name than default (types.ts) and default output (generated-types.ts). Make sure the files exist : p `yarn build && yarn start -i types1.ts -o result.ts` 