### PR TITLE
Feature/add jsdoc to typebox 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts2typebox",
-  "version": "1.0.8",
-  "description": "Create typebox types based on typescript types",
+  "version": "1.1.0",
+  "description": "Creates typebox JSON schemas from typescript types",
   "main": "dist/src/index.js",
   "source": "dist/src/index.js",
   "bin": {
@@ -12,9 +12,6 @@
     "build": "tsc",
     "watch-ts": "tsc -w",
     "test": "tsc && node --test --test-reporter spec dist/tests/*.js",
-    "semver-patch": "npm version patch -f",
-    "semver-minor": "npm version minor -f",
-    "publish": "npm publish",
     "start": "node dist/src/index.js"
   },
   "repository": {
@@ -45,9 +42,9 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
-    "@types/minimist": "^1.2.2",
+    "@types/minimist": "1.2.2",
     "@types/node": "18.15.3",
-    "@types/prettier": "^2.7.2",
+    "@types/prettier": "2.7.2",
     "tsconfig-paths": "4.1.2"
   }
 }

--- a/src/jsdoc-to-typebox.ts
+++ b/src/jsdoc-to-typebox.ts
@@ -1,0 +1,80 @@
+/**
+ * Functions used to add ability to parse jsdoc comments for types into JSON
+ * schema options.
+ **/
+import * as ts from "typescript";
+import * as doctrine from "doctrine";
+
+const getJsDocStringFromNode = (node: ts.TypeAliasDeclaration): string[] => {
+  const regexToGetComments = /\/\*\*([\s\S]*?)\*\//;
+  const match = node.getFullText().match(regexToGetComments);
+  if (match !== undefined && match !== null) {
+    return match.slice(1);
+  }
+  return [];
+};
+
+// const isNumericOption = (tag: doctrine.Tag): boolean => {
+//   const numericOptions = ['exclusiveMaximum', 'exclusiveMinimum', 'maximum', 'minimum', 'multipleOf']
+//   return numericOptions.includes(tag.title)
+// }
+
+const astTagsFromJsDoc = (jsDocStrings: string): doctrine.Tag[] => {
+  const { tags } = doctrine.parse(jsDocStrings, { unwrap: true });
+  return tags;
+};
+
+const generateOptionsForNode = (
+  tags: doctrine.Tag[],
+  transform: (val: number | bigint | string) => number | bigint | string
+) => {
+  return tags.reduce((prev, curr) => {
+    if (curr.description !== null) {
+      prev[curr.title] = transform(curr.description);
+    }
+    return prev;
+  }, {} as Record<any, any>);
+};
+
+// const isNumericNode = (node: ts.TypeAliasDeclaration) => {
+//   const children = node.getChildren()
+//   return children.map((child) => child.kind).includes(ts.SyntaxKind.NumberKeyword)
+// }
+
+/**
+ * Generates an object containing valid JSON schema options for the given node
+ * based on the given jsdoc ast.
+ **/
+export const generateOptionsBasedOnJsDocOfNode = (
+  node: ts.TypeAliasDeclaration
+) => {
+  const jsDocStrings = getJsDocStringFromNode(node);
+  const tags = jsDocStrings.flatMap(astTagsFromJsDoc);
+  return generateOptionsForNode(tags, (val) => {
+    if (typeof val === "number") {
+      return val;
+    }
+    if (typeof val === "string") {
+      console.log(val);
+      if (val.endsWith("n")) {
+        return BigInt(val);
+      }
+      return parseInt(val, 10);
+    }
+    return val;
+  });
+};
+
+/**
+ * Adds given JSON schema options to the string representation of the given
+ * type.
+ **/
+export const addOptionsToType = (
+  typeAsString: string,
+  options: Record<any, any>
+) => {
+  if (Object.keys(options).length === 0) {
+    return typeAsString;
+  }
+  return `${typeAsString.slice(0, -1)}${JSON.stringify(options)})`;
+};

--- a/src/jsdoc-to-typebox.ts
+++ b/src/jsdoc-to-typebox.ts
@@ -5,7 +5,9 @@
 import * as ts from "typescript";
 import * as doctrine from "doctrine";
 
-const getJsDocStringFromNode = (node: ts.TypeAliasDeclaration): string[] => {
+const getJsDocStringFromNode = (
+  node: ts.TypeAliasDeclaration | ts.PropertySignature
+): string[] => {
   const regexToGetComments = /\/\*\*([\s\S]*?)\*\//;
   const match = node.getFullText().match(regexToGetComments);
   if (match !== undefined && match !== null) {
@@ -13,11 +15,6 @@ const getJsDocStringFromNode = (node: ts.TypeAliasDeclaration): string[] => {
   }
   return [];
 };
-
-// const isNumericOption = (tag: doctrine.Tag): boolean => {
-//   const numericOptions = ['exclusiveMaximum', 'exclusiveMinimum', 'maximum', 'minimum', 'multipleOf']
-//   return numericOptions.includes(tag.title)
-// }
 
 const astTagsFromJsDoc = (jsDocStrings: string): doctrine.Tag[] => {
   const { tags } = doctrine.parse(jsDocStrings, { unwrap: true });
@@ -36,17 +33,12 @@ const generateOptionsForNode = (
   }, {} as Record<any, any>);
 };
 
-// const isNumericNode = (node: ts.TypeAliasDeclaration) => {
-//   const children = node.getChildren()
-//   return children.map((child) => child.kind).includes(ts.SyntaxKind.NumberKeyword)
-// }
-
 /**
  * Generates an object containing valid JSON schema options for the given node
  * based on the given jsdoc ast.
  **/
 export const generateOptionsBasedOnJsDocOfNode = (
-  node: ts.TypeAliasDeclaration
+  node: ts.TypeAliasDeclaration | ts.PropertySignature
 ) => {
   const jsDocStrings = getJsDocStringFromNode(node);
   const tags = jsDocStrings.flatMap(astTagsFromJsDoc);
@@ -55,10 +47,21 @@ export const generateOptionsBasedOnJsDocOfNode = (
       return val;
     }
     if (typeof val === "string") {
-      console.log(val);
+      // bigint
       if (val.endsWith("n")) {
         return BigInt(val);
       }
+      // string
+      // TODO: should we also allow quoted strings via 'test here'?
+      if (val.startsWith('"')) {
+        const valAfterFirstQuote = val.slice(1);
+        // does it contain another (closing) '"'?
+        if (valAfterFirstQuote.includes('"')) {
+          const valInsideQuotes = valAfterFirstQuote.split('"')[0];
+          return valInsideQuotes;
+        }
+      }
+      // number
       return parseInt(val, 10);
     }
     return val;
@@ -76,5 +79,8 @@ export const addOptionsToType = (
   if (Object.keys(options).length === 0) {
     return typeAsString;
   }
+  // TODO: probably add ": SchemaOptions" here. Was mentioned in discussion, but I
+  // did not find the type anywhere? Perhaps I misunderstood something?
+  // src: https://github.com/sinclairzx81/typebox-codegen/discussions/13#discussioncomment-5858910
   return `${typeAsString.slice(0, -1)}${JSON.stringify(options)})`;
 };

--- a/src/typescript-to-typebox.ts
+++ b/src/typescript-to-typebox.ts
@@ -25,6 +25,10 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import * as ts from "typescript";
+import {
+  addOptionsToType,
+  generateOptionsBasedOnJsDocOfNode,
+} from "./jsdoc-to-typebox";
 
 export class TypeScriptToTypeBoxError extends Error {
   constructor(public readonly diagnostics: ts.Diagnostic[]) {
@@ -77,6 +81,8 @@ export namespace TypeScriptToTypeBox {
   let blockLevel: number = 0;
   // (auto) tracked for injecting typebox import statements
   let useImports = false;
+  // (auto) tracked for injecting JSON schema optios
+  let useOptions = false;
   // (auto) tracked for injecting TSchema import statements
   let useGenerics = false;
   // (auto) tracked for cases where composition requires deep clone
@@ -152,22 +158,25 @@ export namespace TypeScriptToTypeBox {
   // code generation, we tend to prefer referential types as these can be both inlined or referenced in
   // the codegen target; and where different targets may have different referential requirements. It
   // should be possible to implement a more robust injection mechanism however. For review.
-  function InjectIdentifier($id: string, type: string) {
+  function InjectIdentifier($id: string, type: string, useOptions: boolean) {
+    const options = useOptions
+      ? `{ $id: '${$id}', ...options }`
+      : `{ $id: '${$id}' }`;
     if (!useIdentifiers) return type;
     // indexer type
     if (type.lastIndexOf("]") === type.length - 1) useTypeClone = true;
     if (type.lastIndexOf("]") === type.length - 1)
-      return `TypeClone.Clone(${type}, { $id: '${$id}' })`;
+      return `TypeClone.Clone(${type}, ${options})`;
     // referenced type
-    if (type.indexOf("(") === -1) return `Type.Ref(${type}, { $id: '${$id}' })`;
+    if (type.indexOf("(") === -1) return `Type.Ref(${type}, ${options})`;
     if (type.lastIndexOf("()") === type.length - 2)
-      return type.slice(0, type.length - 1) + `{ $id: '${$id}' })`;
+      return type.slice(0, type.length - 1) + `${options})`;
     if (type.lastIndexOf("})") === type.length - 2)
-      return type.slice(0, type.length - 1) + `, { $id: '${$id}' })`;
+      return type.slice(0, type.length - 1) + `, ${options})`;
     if (type.lastIndexOf("])") === type.length - 2)
-      return type.slice(0, type.length - 1) + `, { $id: '${$id}' })`;
+      return type.slice(0, type.length - 1) + `, ${options})`;
     if (type.lastIndexOf(")") === type.length - 1)
-      return type.slice(0, type.length - 1) + `, { $id: '${$id}' })`;
+      return type.slice(0, type.length - 1) + `, ${options})`;
     return type;
   }
   // ------------------------------------------------------------------------------------------------------------
@@ -361,8 +370,15 @@ export namespace TypeScriptToTypeBox {
         heritage.length === 0
           ? rawTypeExpression
           : `Type.Intersect([${heritage.join(", ")}, ${rawTypeExpression}])`;
-      const type = InjectIdentifier(ResolveIdentifier(node), typeExpression);
-      const typeDeclaration = `${exports}const ${node.name.getText()} = <${constraints}>(${parameters}) => ${type}`;
+      const type = InjectIdentifier(
+        ResolveIdentifier(node),
+        typeExpression,
+        true && useIdentifiers
+      );
+      const options =
+        true && useIdentifiers ? ", options: SchemaOptions = {}" : "";
+      useOptions = useOptions || (true && useIdentifiers); // todo: refactor this
+      const typeDeclaration = `${exports}const ${node.name.getText()} = <${constraints}>(${parameters}${options}) => ${type}`;
       yield `${staticDeclaration}\n${typeDeclaration}`;
     } else {
       const exports = IsExport(node) ? "export " : "";
@@ -375,17 +391,23 @@ export namespace TypeScriptToTypeBox {
         heritage.length === 0
           ? rawTypeExpression
           : `Type.Intersect([${heritage.join(", ")}, ${rawTypeExpression}])`;
-      const type = InjectIdentifier(ResolveIdentifier(node), typeExpression);
+      const type = InjectIdentifier(
+        ResolveIdentifier(node),
+        typeExpression,
+        false
+      );
       const typeDeclaration = `${exports}const ${node.name.getText()} = ${type}`;
       yield `${staticDeclaration}\n${typeDeclaration}`;
     }
     typeNames.add(node.name.getText());
     recursiveDeclaration = null;
   }
+
   function* TypeAliasDeclaration(
     node: ts.TypeAliasDeclaration
   ): IterableIterator<string> {
     useImports = true;
+    const jsonSchemaOptions = generateOptionsBasedOnJsDocOfNode(node);
     const isRecursiveType = IsRecursiveType(node);
     if (isRecursiveType) recursiveDeclaration = node;
     if (node.typeParameters) {
@@ -404,9 +426,16 @@ export namespace TypeScriptToTypeBox {
       const type_1 = isRecursiveType
         ? `Type.Recursive(This => ${type_0})`
         : type_0;
-      const type_2 = InjectIdentifier(ResolveIdentifier(node), type_1);
+      const type_2 = InjectIdentifier(
+        ResolveIdentifier(node),
+        type_1,
+        true && useIdentifiers
+      );
+      const options =
+        true && useIdentifiers ? ", options: SchemaOptions = {}" : "";
+      useOptions = useOptions || (true && useIdentifiers); // todo: refactor this
       const staticDeclaration = `${exports}type ${node.name.getText()}<${constraints}> = Static<ReturnType<typeof ${node.name.getText()}<${names}>>>`;
-      const typeDeclaration = `${exports}const ${node.name.getText()} = <${constraints}>(${parameters}) => ${type_2}`;
+      const typeDeclaration = `${exports}const ${node.name.getText()} = <${constraints}>(${parameters}${options}) => ${type_2}`;
       yield `${staticDeclaration}\n${typeDeclaration}`;
     } else {
       const exports = IsExport(node) ? "export " : "";
@@ -414,9 +443,12 @@ export namespace TypeScriptToTypeBox {
       const type_1 = isRecursiveType
         ? `Type.Recursive(This => ${type_0})`
         : type_0;
-      const type_2 = InjectIdentifier(ResolveIdentifier(node), type_1);
+      const type_2 = InjectIdentifier(ResolveIdentifier(node), type_1, false);
       const staticDeclaration = `${exports}type ${node.name.getText()} = Static<typeof ${node.name.getText()}>`;
-      const typeDeclaration = `${exports}const ${node.name.getText()} = ${type_2}`;
+      const typeDeclaration = `${exports}const ${node.name.getText()} = ${addOptionsToType(
+        type_2,
+        jsonSchemaOptions
+      )}`;
       yield `${staticDeclaration}\n${typeDeclaration}`;
     }
     typeNames.add(node.name.getText());
@@ -613,15 +645,14 @@ export namespace TypeScriptToTypeBox {
     }
     console.warn("Unhandled:", ts.SyntaxKind[node.kind], node.getText());
   }
-
   export function ImportStatement(options: TypeScriptToTypeBoxOptions): string {
     if (!(useImports && options.useTypeBoxImport)) return "";
     const imported = ["Type", "Static"];
     if (useGenerics) imported.push("TSchema");
+    if (useOptions) imported.push("SchemaOptions");
     if (useTypeClone) imported.push("TypeClone");
     return `import { ${imported.join(", ")} } from '@sinclair/typebox'`;
   }
-
   /** Generates TypeBox types from TypeScript interface and type definitions */
   export function Generate(
     typescriptCode: string,
@@ -635,6 +666,7 @@ export namespace TypeScriptToTypeBox {
     useIdentifiers = options.useIdentifiers;
     typeNames.clear();
     useImports = false;
+    useOptions = false;
     useGenerics = false;
     useTypeClone = false;
     blockLevel = 0;

--- a/src/typescript-to-typebox.ts
+++ b/src/typescript-to-typebox.ts
@@ -195,6 +195,7 @@ export namespace TypeScriptToTypeBox {
       IsOptionalProperty(node),
     ];
     const type = Collect(node.type);
+    const jsonSchemaOptions = generateOptionsBasedOnJsDocOfNode(node);
     if (readonly && optional) {
       return yield `${node.name.getText()}: Type.ReadonlyOptional(${type})`;
     } else if (readonly) {
@@ -202,7 +203,10 @@ export namespace TypeScriptToTypeBox {
     } else if (optional) {
       return yield `${node.name.getText()}: Type.Optional(${type})`;
     } else {
-      return yield `${node.name.getText()}: ${type}`;
+      return yield `${node.name.getText()}: ${addOptionsToType(
+        type,
+        jsonSchemaOptions
+      )}`;
     }
   }
   function* ArrayTypeNode(node: ts.ArrayTypeNode): IterableIterator<string> {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -344,4 +344,160 @@ describe("ts2typebox - Typescript to Typebox", () => {
     `;
     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
+  describe("jsdoc to JSON schema options", () => {
+    describe("number", () => {
+      test("minimum - TypeAliasDeclaration", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @minimum 4
+         */
+        type X = number;
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type X = Static<typeof X>;
+        const X = Type.Number({ minimum: 4 });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+      // TODO: adapt implementation to fix this.
+      test("type", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @minimum 100
+         * @maximum 200
+         * @multipleOf 2
+         * @default 150
+         * @description "it's a number" - strings must be quoted
+         * @foobar "should support unknown props"
+         */
+        type T = number;
+        }
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type T = Static<typeof T>;
+        const T = Type.Number({
+            minimum: 100,
+            maximum: 200,
+            multipleOf: 2,
+            default: 150,
+            description: "it's a number",
+            foobar: "should support unknown props",
+        });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+      // test('interface', () => {
+      //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      //   interface T {
+      //     /**
+      //      * @minimum 100
+      //      * @minimum 200
+      //      * @multipleOf 2
+      //      * @default 150
+      //      * @description "it's a number" - strings must be quoted
+      //      * @foobar "should support unknown props"
+      //      */
+      //     x: number;
+      //   }
+      //   `)
+      //   const expectedResult = `
+      //   import { Type, Static } from "@sinclair/typebox";
+      //
+      //   type T = Static<typeof T>;
+      //   const T = Type.Object({
+      //     x: Type.Number({
+      //       minimum: 100,
+      //       maximum: 200,
+      //       multipleOf: 2,
+      //       default: 150,
+      //       description: "it's a number",
+      //       foobar: "should support unknown props",
+      //     }),
+      //   });
+      //   `
+      //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult)
+      // })
+      test("maximum", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @maximum 4
+         */
+        type X = number;
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type X = Static<typeof X>;
+        const X = Type.Number({ maximum: 4 });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+      test("exclusiveMaximum", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @exclusiveMaximum 4
+         */
+        type X = number;
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type X = Static<typeof X>;
+        const X = Type.Number({ exclusiveMaximum: 4 });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+      test("exclusiveMinimum", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @exclusiveMinimum 4
+         */
+        type X = number;
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type X = Static<typeof X>;
+        const X = Type.Number({ exclusiveMinimum: 4 });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+      test("multipleOf", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @multipleOf 4
+         */
+        type X = number;
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type X = Static<typeof X>;
+        const X = Type.Number({ multipleOf: 4 });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+      test("multiple jsdoc comments", () => {
+        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        /**
+         * @minimum 2
+         * @maximum 8
+         * @multipleOf 2
+         */
+        type X = number;
+        `);
+        const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type X = Static<typeof X>;
+        const X = Type.Number({ minimum: 2, maximum: 8, multipleOf: 2 });
+        `;
+        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      });
+    });
+  });
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -345,25 +345,8 @@ describe("ts2typebox - Typescript to Typebox", () => {
     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
   describe("jsdoc to JSON schema options", () => {
-    describe("number", () => {
-      test("minimum - TypeAliasDeclaration", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        /**
-         * @minimum 4
-         */
-        type X = number;
-        `);
-        const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type X = Static<typeof X>;
-        const X = Type.Number({ minimum: 4 });
-        `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
-      // TODO: adapt implementation to fix this.
-      test("type", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    test("type", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
         /**
          * @minimum 100
          * @maximum 200
@@ -375,7 +358,7 @@ describe("ts2typebox - Typescript to Typebox", () => {
         type T = number;
         }
         `);
-        const expectedResult = `
+      const expectedResult = `
         import { Type, Static } from "@sinclair/typebox";
 
         type T = Static<typeof T>;
@@ -388,116 +371,38 @@ describe("ts2typebox - Typescript to Typebox", () => {
             foobar: "should support unknown props",
         });
         `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
-      // test('interface', () => {
-      //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
-      //   interface T {
-      //     /**
-      //      * @minimum 100
-      //      * @minimum 200
-      //      * @multipleOf 2
-      //      * @default 150
-      //      * @description "it's a number" - strings must be quoted
-      //      * @foobar "should support unknown props"
-      //      */
-      //     x: number;
-      //   }
-      //   `)
-      //   const expectedResult = `
-      //   import { Type, Static } from "@sinclair/typebox";
-      //
-      //   type T = Static<typeof T>;
-      //   const T = Type.Object({
-      //     x: Type.Number({
-      //       minimum: 100,
-      //       maximum: 200,
-      //       multipleOf: 2,
-      //       default: 150,
-      //       description: "it's a number",
-      //       foobar: "should support unknown props",
-      //     }),
-      //   });
-      //   `
-      //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult)
-      // })
-      test("maximum", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        /**
-         * @maximum 4
-         */
-        type X = number;
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    test("interface", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        interface T {
+          /**
+           * @minimum 100
+           * @maximum 200
+           * @multipleOf 2
+           * @default 150
+           * @description "it's a number" - strings must be quoted
+           * @foobar "should support unknown props"
+           */
+          x: number;
+        }
         `);
-        const expectedResult = `
+      const expectedResult = `
         import { Type, Static } from "@sinclair/typebox";
 
-        type X = Static<typeof X>;
-        const X = Type.Number({ maximum: 4 });
+        type T = Static<typeof T>;
+        const T = Type.Object({
+          x: Type.Number({
+            minimum: 100,
+            maximum: 200,
+            multipleOf: 2,
+            default: 150,
+            description: "it's a number",
+            foobar: "should support unknown props",
+          }),
+        });
         `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
-      test("exclusiveMaximum", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        /**
-         * @exclusiveMaximum 4
-         */
-        type X = number;
-        `);
-        const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type X = Static<typeof X>;
-        const X = Type.Number({ exclusiveMaximum: 4 });
-        `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
-      test("exclusiveMinimum", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        /**
-         * @exclusiveMinimum 4
-         */
-        type X = number;
-        `);
-        const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type X = Static<typeof X>;
-        const X = Type.Number({ exclusiveMinimum: 4 });
-        `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
-      test("multipleOf", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        /**
-         * @multipleOf 4
-         */
-        type X = number;
-        `);
-        const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type X = Static<typeof X>;
-        const X = Type.Number({ multipleOf: 4 });
-        `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
-      test("multiple jsdoc comments", () => {
-        const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        /**
-         * @minimum 2
-         * @maximum 8
-         * @multipleOf 2
-         */
-        type X = number;
-        `);
-        const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type X = Static<typeof X>;
-        const X = Type.Number({ minimum: 2, maximum: 8, multipleOf: 2 });
-        `;
-        expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-      });
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
     });
   });
 });


### PR DESCRIPTION
ts2typebox now correctly generates JSON schema options based on given jsdoc comments inside typescript types.

Example:
```types.ts
        /**
         * @minimum 100
         * @maximum 200
         * @multipleOf 2
         * @default 150
         * @description "it's a number" - strings must be quoted
         * @foobar "should support unknown props"
         */
        type T = number;
```
running ts2typebox yields the following generated types:
```
        import { Type, Static } from "@sinclair/typebox";

        type T = Static<typeof T>;
        const T = Type.Number({
            minimum: 100,
            maximum: 200,
            multipleOf: 2,
            default: 150,
            description: "it's a number",
            foobar: "should support unknown props",
        });

```
Does also work for interfaces.

## How to test
- run `yarn test`