### PR TITLE
Feature/fix jsdoc to typescript for readonly and optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2typebox",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Creates typebox JSON schemas from typescript types",
   "main": "dist/src/index.js",
   "source": "dist/src/index.js",

--- a/src/jsdoc-to-typebox.ts
+++ b/src/jsdoc-to-typebox.ts
@@ -79,8 +79,23 @@ export const addOptionsToType = (
   if (Object.keys(options).length === 0) {
     return typeAsString;
   }
+
+  const closingParensCount = getNumberOfEndingClosingParens(typeAsString);
+
   // TODO: probably add ": SchemaOptions" here. Was mentioned in discussion, but I
   // did not find the type anywhere? Perhaps I misunderstood something?
   // src: https://github.com/sinclairzx81/typebox-codegen/discussions/13#discussioncomment-5858910
-  return `${typeAsString.slice(0, -1)}${JSON.stringify(options)})`;
+  return `${typeAsString.slice(0, closingParensCount * -1)}${JSON.stringify(
+    options
+  )}${")".repeat(closingParensCount)}`;
+};
+
+const getNumberOfEndingClosingParens = (type: string) => {
+  let currentType = type;
+  let closingEndingParensCount = 0;
+  while (currentType.endsWith(")")) {
+    currentType = currentType.slice(0, -1);
+    closingEndingParensCount = closingEndingParensCount + 1;
+  }
+  return closingEndingParensCount;
 };

--- a/src/jsdoc-to-typebox.ts
+++ b/src/jsdoc-to-typebox.ts
@@ -6,7 +6,7 @@ import * as ts from "typescript";
 import * as doctrine from "doctrine";
 
 const getJsDocStringFromNode = (
-  node: ts.TypeAliasDeclaration | ts.PropertySignature
+  node: ts.TypeAliasDeclaration | ts.PropertySignature | ts.InterfaceDeclaration
 ): string[] => {
   const regexToGetComments = /\/\*\*([\s\S]*?)\*\//;
   const match = node.getFullText().match(regexToGetComments);
@@ -38,7 +38,7 @@ const generateOptionsForNode = (
  * based on the given jsdoc ast.
  **/
 export const generateOptionsBasedOnJsDocOfNode = (
-  node: ts.TypeAliasDeclaration | ts.PropertySignature
+  node: ts.TypeAliasDeclaration | ts.PropertySignature | ts.InterfaceDeclaration
 ) => {
   const jsDocStrings = getJsDocStringFromNode(node);
   const tags = jsDocStrings.flatMap(astTagsFromJsDoc);
@@ -74,9 +74,9 @@ export const generateOptionsBasedOnJsDocOfNode = (
  **/
 export const addOptionsToType = (
   typeAsString: string,
-  options: Record<any, any>
+  options?: Record<any, any>
 ) => {
-  if (Object.keys(options).length === 0) {
+  if (options === undefined || Object.keys(options).length === 0) {
     return typeAsString;
   }
 

--- a/src/jsdoc-to-typebox.ts
+++ b/src/jsdoc-to-typebox.ts
@@ -80,22 +80,20 @@ export const addOptionsToType = (
     return typeAsString;
   }
 
-  const closingParensCount = getNumberOfEndingClosingParens(typeAsString);
+  // const closingParensCount = getNumberOfEndingClosingParens(typeAsString);
 
   // TODO: probably add ": SchemaOptions" here. Was mentioned in discussion, but I
   // did not find the type anywhere? Perhaps I misunderstood something?
   // src: https://github.com/sinclairzx81/typebox-codegen/discussions/13#discussioncomment-5858910
-  return `${typeAsString.slice(0, closingParensCount * -1)}${JSON.stringify(
-    options
-  )}${")".repeat(closingParensCount)}`;
+  return `${typeAsString.slice(0, -1)},${JSON.stringify(options)})`;
 };
 
-const getNumberOfEndingClosingParens = (type: string) => {
-  let currentType = type;
-  let closingEndingParensCount = 0;
-  while (currentType.endsWith(")")) {
-    currentType = currentType.slice(0, -1);
-    closingEndingParensCount = closingEndingParensCount + 1;
-  }
-  return closingEndingParensCount;
-};
+// const getNumberOfEndingClosingParens = (type: string) => {
+//   let currentType = type;
+//   let closingEndingParensCount = 0;
+//   while (currentType.endsWith(")")) {
+//     currentType = currentType.slice(0, -1);
+//     closingEndingParensCount = closingEndingParensCount + 1;
+//   }
+//   return closingEndingParensCount;
+// };

--- a/src/jsdoc-to-typebox.ts
+++ b/src/jsdoc-to-typebox.ts
@@ -52,7 +52,7 @@ export const generateOptionsBasedOnJsDocOfNode = (
         return BigInt(val);
       }
       // string
-      // TODO: should we also allow quoted strings via 'test here'?
+      // TODO: also allow quoted strings via 'test here'?
       if (val.startsWith('"')) {
         const valAfterFirstQuote = val.slice(1);
         // does it contain another (closing) '"'?

--- a/src/typescript-to-typebox.ts
+++ b/src/typescript-to-typebox.ts
@@ -196,17 +196,16 @@ export namespace TypeScriptToTypeBox {
     ];
     const type = Collect(node.type);
     const jsonSchemaOptions = generateOptionsBasedOnJsDocOfNode(node);
+    const typeWithJsonSchemaOptions = addOptionsToType(type, jsonSchemaOptions);
+
     if (readonly && optional) {
-      return yield `${node.name.getText()}: Type.ReadonlyOptional(${type})`;
+      return yield `${node.name.getText()}: Type.ReadonlyOptional(${typeWithJsonSchemaOptions})`;
     } else if (readonly) {
-      return yield `${node.name.getText()}: Type.Readonly(${type})`;
+      return yield `${node.name.getText()}: Type.Readonly(${typeWithJsonSchemaOptions})`;
     } else if (optional) {
-      return yield `${node.name.getText()}: Type.Optional(${type})`;
+      return yield `${node.name.getText()}: Type.Optional(${typeWithJsonSchemaOptions})`;
     } else {
-      return yield `${node.name.getText()}: ${addOptionsToType(
-        type,
-        jsonSchemaOptions
-      )}`;
+      return yield `${node.name.getText()}: ${typeWithJsonSchemaOptions}`;
     }
   }
   function* ArrayTypeNode(node: ts.ArrayTypeNode): IterableIterator<string> {

--- a/src/typescript-to-typebox.ts
+++ b/src/typescript-to-typebox.ts
@@ -458,7 +458,6 @@ export namespace TypeScriptToTypeBox {
       const exports = IsExport(node) ? "export " : "";
       schemaOptions.push(jsonSchemaOptions);
       const type_0 = Collect(node.type);
-      console.log("collected type in TypeAliasDeclaration", type_0);
       const type_1 = isRecursiveType
         ? `Type.Recursive(This => ${type_0})`
         : type_0;

--- a/src/typescript-to-typebox.ts
+++ b/src/typescript-to-typebox.ts
@@ -195,9 +195,6 @@ export namespace TypeScriptToTypeBox {
       IsOptionalProperty(node),
     ];
     const type = Collect(node.type);
-    // const jsonSchemaOptions = generateOptionsBasedOnJsDocOfNode(node);
-    // const typeWithJsonSchemaOptions = addOptionsToType(type, jsonSchemaOptions);
-
     if (readonly && optional) {
       return yield `${node.name.getText()}: Type.ReadonlyOptional(${type})`;
     } else if (readonly) {
@@ -287,7 +284,7 @@ export namespace TypeScriptToTypeBox {
       yield `Type.KeyOf(${type})`;
     }
     if (node.operator === ts.SyntaxKind.ReadonlyKeyword) {
-      yield Collect(node.type);
+      yield `Type.Readonly(${Collect(node.type)})`;
     }
   }
   function* Parameter(node: ts.ParameterDeclaration): IterableIterator<string> {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -20,333 +20,333 @@ export const expectEqualIgnoreFormatting = (
   assert.equal(formatWithPrettier(input1), formatWithPrettier(input2));
 };
 
-// describe("ts2typebox - Typescript to Typebox", () => {
-//   test("string", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string`);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type T = Static<typeof T>;
-//       const T = Type.String();
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("number", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = number`);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type T = Static<typeof T>;
-//       const T = Type.Number();
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("boolean", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = boolean`);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type T = Static<typeof T>;
-//       const T = Type.Boolean();
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("any", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = any`);
-//     const expectedResult = `
-//       import { Type, Static } from '@sinclair/typebox'
-//
-//       type T = Static<typeof T>
-//       const T = Type.Any()
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("unknown", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = unknown`);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type T = Static<typeof T>;
-//       const T = Type.Unknown();
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("never", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = never`);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type T = Static<typeof T>;
-//       const T = Type.Never();
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("null", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = null`);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Null();
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Array<string>", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(
-//       `type T = Array<string>`
-//     );
-//     const expectedResult = `
-//         import { Type, Static } from "@sinclair/typebox";
-//
-//         type T = Static<typeof T>;
-//         const T = Type.Array(Type.String());
-//         `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("string[]", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string[]`);
-//     const expectedResult = `
-//         import { Type, Static } from "@sinclair/typebox";
-//
-//         type T = Static<typeof T>;
-//         const T = Type.Array(Type.String());
-//         `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Union", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//       type A = number;
-//       type B = string;
-//
-//       type T = A | B;
-//         `);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type A = Static<typeof A>;
-//       const A = Type.Number();
-//
-//       type B = Static<typeof B>;
-//       const B = Type.String();
-//
-//       type T = Static<typeof T>;
-//       const T = Type.Union([A, B]);`;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Intersect", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//       type T = {
-//         x: number;
-//       } & {
-//         y: string;
-//       };
-//     `);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Intersect([
-//       Type.Object({
-//         x: Type.Number(),
-//       }),
-//       Type.Object({
-//         y: Type.String(),
-//       }),
-//     ]);
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Literal", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//       type T = "a" | "b";
-//       `);
-//     const expectedResult = `
-//       import { Type, Static } from "@sinclair/typebox";
-//
-//       type T = Static<typeof T>;
-//       const T = Type.Union([Type.Literal("a"), Type.Literal("b")]);`;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Object", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//        type T = {
-//          a: number;
-//          b: string;
-//        };
-//       `);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Object({
-//       a: Type.Number(),
-//       b: Type.String(),
-//     });
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Tuple", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//     type T = [number, null];
-//       `);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Tuple([Type.Number(), Type.Null()]);
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Enum", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//     enum A {
-//       A,
-//       B,
-//     }
-//
-//     type T = A;
-//     `);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     enum AEnum {
-//       A,
-//       B,
-//     }
-//
-//     const A = Type.Enum(AEnum);
-//
-//     type T = Static<typeof T>;
-//     const T = A;
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("keyof", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//     type T = keyof {
-//       x: number;
-//       y: string;
-//     };
-//     `);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.KeyOf(
-//       Type.Object({
-//         x: Type.Number(),
-//         y: Type.String(),
-//       })
-//     );
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Record", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(
-//       `type T = Record<string, number>;`
-//     );
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Record(Type.String(), Type.Number());
-//       `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Utility - Partial", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(
-//       `type T = Partial<{ a: 1; b: 2 }>;`
-//     );
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Partial(
-//       Type.Object({
-//         a: Type.Literal(1),
-//         b: Type.Literal(2),
-//       })
-//     );
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Utility - Pick", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(
-//       `type T = Pick<{ a: 1; b: 2 }, "a">;`
-//     );
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Pick(
-//       Type.Object({
-//         a: Type.Literal(1),
-//         b: Type.Literal(2),
-//       }),
-//       Type.Literal("a")
-//     );
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Utility - Omit", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(
-//       `type T = Omit<{ a: 1; b: 2 }, "a">;`
-//     );
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Omit(
-//       Type.Object({
-//         a: Type.Literal(1),
-//         b: Type.Literal(2),
-//       }),
-//       Type.Literal("a")
-//     );
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Utility - Required", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(
-//       `type T = Required<{ a?: 1; b?: 2 }>;`
-//     );
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Required(
-//       Type.Object({
-//         a: Type.Optional(Type.Literal(1)),
-//         b: Type.Optional(Type.Literal(2)),
-//       })
-//     );
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-//   test("Indexed Access", () => {
-//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-//     type A = {
-//       a: number;
-//     };
-//
-//     type T = A["a"];
-//     `);
-//     const expectedResult = `
-//     import { Type, Static } from "@sinclair/typebox";
-//
-//     type A = Static<typeof A>;
-//     const A = Type.Object({
-//       a: Type.Number(),
-//     });
-//
-//     type T = Static<typeof T>;
-//     const T = Type.Index(A, Type.Literal("a"));
-//     `;
-//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-//   });
-describe("jsdoc to JSON schema options", () => {
-  test("flat type - number", () => {
+describe("ts2typebox - Typescript to Typebox", () => {
+  test("string", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string`);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.String();
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("number", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = number`);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Number();
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("boolean", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = boolean`);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Boolean();
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("any", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = any`);
+    const expectedResult = `
+      import { Type, Static } from '@sinclair/typebox'
+
+      type T = Static<typeof T>
+      const T = Type.Any()
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("unknown", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = unknown`);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Unknown();
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("never", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = never`);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Never();
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("null", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = null`);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Null();
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Array<string>", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(
+      `type T = Array<string>`
+    );
+    const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type T = Static<typeof T>;
+        const T = Type.Array(Type.String());
+        `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("string[]", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string[]`);
+    const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type T = Static<typeof T>;
+        const T = Type.Array(Type.String());
+        `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Union", () => {
     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type A = number;
+      type B = string;
+
+      type T = A | B;
+        `);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type A = Static<typeof A>;
+      const A = Type.Number();
+
+      type B = Static<typeof B>;
+      const B = Type.String();
+
+      type T = Static<typeof T>;
+      const T = Type.Union([A, B]);`;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Intersect", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type T = {
+        x: number;
+      } & {
+        y: string;
+      };
+    `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Intersect([
+      Type.Object({
+        x: Type.Number(),
+      }),
+      Type.Object({
+        y: Type.String(),
+      }),
+    ]);
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Literal", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type T = "a" | "b";
+      `);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Union([Type.Literal("a"), Type.Literal("b")]);`;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Object", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+       type T = {
+         a: number;
+         b: string;
+       };
+      `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Object({
+      a: Type.Number(),
+      b: Type.String(),
+    });
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Tuple", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    type T = [number, null];
+      `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Tuple([Type.Number(), Type.Null()]);
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Enum", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    enum A {
+      A,
+      B,
+    }
+
+    type T = A;
+    `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    enum AEnum {
+      A,
+      B,
+    }
+
+    const A = Type.Enum(AEnum);
+
+    type T = Static<typeof T>;
+    const T = A;
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("keyof", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    type T = keyof {
+      x: number;
+      y: string;
+    };
+    `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.KeyOf(
+      Type.Object({
+        x: Type.Number(),
+        y: Type.String(),
+      })
+    );
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Record", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(
+      `type T = Record<string, number>;`
+    );
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Record(Type.String(), Type.Number());
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Utility - Partial", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(
+      `type T = Partial<{ a: 1; b: 2 }>;`
+    );
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Partial(
+      Type.Object({
+        a: Type.Literal(1),
+        b: Type.Literal(2),
+      })
+    );
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Utility - Pick", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(
+      `type T = Pick<{ a: 1; b: 2 }, "a">;`
+    );
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Pick(
+      Type.Object({
+        a: Type.Literal(1),
+        b: Type.Literal(2),
+      }),
+      Type.Literal("a")
+    );
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Utility - Omit", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(
+      `type T = Omit<{ a: 1; b: 2 }, "a">;`
+    );
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Omit(
+      Type.Object({
+        a: Type.Literal(1),
+        b: Type.Literal(2),
+      }),
+      Type.Literal("a")
+    );
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Utility - Required", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(
+      `type T = Required<{ a?: 1; b?: 2 }>;`
+    );
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Required(
+      Type.Object({
+        a: Type.Optional(Type.Literal(1)),
+        b: Type.Optional(Type.Literal(2)),
+      })
+    );
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("Indexed Access", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    type A = {
+      a: number;
+    };
+
+    type T = A["a"];
+    `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type A = Static<typeof A>;
+    const A = Type.Object({
+      a: Type.Number(),
+    });
+
+    type T = Static<typeof T>;
+    const T = Type.Index(A, Type.Literal("a"));
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  describe("jsdoc to JSON schema options", () => {
+    test("flat type - number", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
       /**
        * @minimum 100
        * @maximum 200
@@ -357,7 +357,7 @@ describe("jsdoc to JSON schema options", () => {
        */
       type T = number;
       `);
-    const expectedResult = `
+      const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
@@ -370,10 +370,10 @@ describe("jsdoc to JSON schema options", () => {
           foobar: "should support unknown props",
       });
       `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("type with properties - number", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    test("type with properties - number", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
       type T = {
        /**
         * @minimum 100
@@ -386,7 +386,7 @@ describe("jsdoc to JSON schema options", () => {
         a: number;
       }
       `);
-    const expectedResult = `
+      const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
@@ -399,10 +399,10 @@ describe("jsdoc to JSON schema options", () => {
           foobar: "should support unknown props",
       })});
       `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("type with properties - string", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    test("type with properties - string", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
       type T = {
        /**
         * @minimum 100
@@ -415,7 +415,7 @@ describe("jsdoc to JSON schema options", () => {
         a: string;
       }
       `);
-    const expectedResult = `
+      const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
@@ -428,10 +428,10 @@ describe("jsdoc to JSON schema options", () => {
           foobar: "should support unknown props",
       })});
       `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("type - optional", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    test("type - optional", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
       type T = {
         /**
          * @multipleOf 2
@@ -439,7 +439,7 @@ describe("jsdoc to JSON schema options", () => {
         a?: number;
       }
       `);
-    const expectedResult = `
+      const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
@@ -447,10 +447,10 @@ describe("jsdoc to JSON schema options", () => {
         a: Type.Optional(Type.Number({ multipleOf: 2 })),
       });
       `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("type - number[]", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    test("type - number[]", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
       type T = {
         /**
          * @minItems 2
@@ -459,7 +459,7 @@ describe("jsdoc to JSON schema options", () => {
         a: number[];
       }
       `);
-    const expectedResult = `
+      const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
@@ -467,35 +467,35 @@ describe("jsdoc to JSON schema options", () => {
         a: Type.Array(Type.Number(), { minItems: 2, maxItems: 4 }),
       });
       `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  // TODO: For now Array<number> is unsupported. Seems to be that Array<number>
-  // is treated like it is a "number" instead of Array<number> on the first
-  // look. For now ignore it, perhaps check if something is of type
-  // Numberkeyword if it is wrapped by an Array in typescript to typebox code
-  // (if my assumption is correct :]).
-  // test("type - Array<number>", () => {
-  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
-  //     type T = {
-  //       /**
-  //        * @minItems 2
-  //        * @maxItems 4
-  //        */
-  //       a: Array<number>;
-  //     }
-  //     `);
-  //   const expectedResult = `
-  //     import { Type, Static } from "@sinclair/typebox";
-  //
-  //     type T = Static<typeof T>;
-  //     const T = Type.Object({
-  //       a: Type.Array(Type.Number(), { minItems: 2, maxItems: 4 }),
-  //     });
-  //     `;
-  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  // });
-  test("type - readonly number[]", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    // TODO: For now Array<number> is unsupported. Seems to be that Array<number>
+    // is treated like it is a "number" instead of Array<number> on the first
+    // look. For now ignore it, perhaps check if something is of type
+    // Numberkeyword if it is wrapped by an Array in typescript to typebox code
+    // (if my assumption is correct :]).
+    // test("type - Array<number>", () => {
+    //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    //     type T = {
+    //       /**
+    //        * @minItems 2
+    //        * @maxItems 4
+    //        */
+    //       a: Array<number>;
+    //     }
+    //     `);
+    //   const expectedResult = `
+    //     import { Type, Static } from "@sinclair/typebox";
+    //
+    //     type T = Static<typeof T>;
+    //     const T = Type.Object({
+    //       a: Type.Array(Type.Number(), { minItems: 2, maxItems: 4 }),
+    //     });
+    //     `;
+    //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    // });
+    test("type - readonly number[]", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
     type T = {
      /**
      * @minItems 2
@@ -504,7 +504,7 @@ describe("jsdoc to JSON schema options", () => {
       a: readonly number[];
     };
     `);
-    const expectedResult = `
+      const expectedResult = `
     import { Type, Static } from "@sinclair/typebox";
 
     type T = Static<typeof T>;
@@ -512,11 +512,11 @@ describe("jsdoc to JSON schema options", () => {
       a: Type.Readonly(Type.Array(Type.Number(), { minItems: 2, maxItems: 4 })),
     });
     `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
 
-  test("type - number | string", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    test("type - number | string", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
       type T = {
        /**
        * @minItems 2
@@ -525,7 +525,7 @@ describe("jsdoc to JSON schema options", () => {
       a: number | string;
       }
       `);
-    const expectedResult = `
+      const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
@@ -533,11 +533,10 @@ describe("jsdoc to JSON schema options", () => {
         a: Type.Union([Type.Number(), Type.String()], { minItems: 2, maxItems: 4 }),
       });
       `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  // TODO: continue here.
-  test("interface", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    test("interface", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
         interface T {
           /**
            * @minimum 100
@@ -550,7 +549,7 @@ describe("jsdoc to JSON schema options", () => {
           x: number;
         }
         `);
-    const expectedResult = `
+      const expectedResult = `
         import { Type, Static } from "@sinclair/typebox";
 
         type T = Static<typeof T>;
@@ -565,44 +564,7 @@ describe("jsdoc to JSON schema options", () => {
           }),
         });
         `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
   });
-  // test("optional", () => {
-  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
-  //     type T = {
-  //       /**
-  //        * @minimum 4
-  //        */
-  //       a?: number
-  //     }
-  //     `);
-  //   const expectedResult = `
-  //     import { Type, Static } from "@sinclair/typebox";
-  //       export const T = Type.Object({
-  //       a: Type.Optional(Type.Number({"minimum": 4}))
-  //       })
-  //     `;
-  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  // });
-  // TODO: fix with arrays.
-  // test("readonly", () => {
-  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
-  //     export type T = {
-  //       /**
-  //        * @minimum 4
-  //        */
-  //       a: readonly number[];
-  //     };
-  //     `);
-  //   const expectedResult = `
-  //     import { Type, Static } from "@sinclair/typebox";
-  //
-  //     export type T = Static<typeof T>;
-  //     export const T = Type.Object({
-  //       a: Type.Array(Type.Number({ minimum: 4 })),
-  //     });
-  //   `;
-  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  // });
-  // });
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -20,425 +20,568 @@ export const expectEqualIgnoreFormatting = (
   assert.equal(formatWithPrettier(input1), formatWithPrettier(input2));
 };
 
-describe("ts2typebox - Typescript to Typebox", () => {
-  test("string", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string`);
-    const expectedResult = `
-      import { Type, Static } from "@sinclair/typebox";
-
-      type T = Static<typeof T>;
-      const T = Type.String();
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("number", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = number`);
-    const expectedResult = `
-      import { Type, Static } from "@sinclair/typebox";
-
-      type T = Static<typeof T>;
-      const T = Type.Number();
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("boolean", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = boolean`);
-    const expectedResult = `
-      import { Type, Static } from "@sinclair/typebox";
-
-      type T = Static<typeof T>;
-      const T = Type.Boolean();
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("any", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = any`);
-    const expectedResult = `
-      import { Type, Static } from '@sinclair/typebox'
-
-      type T = Static<typeof T>
-      const T = Type.Any()
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("unknown", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = unknown`);
-    const expectedResult = `
-      import { Type, Static } from "@sinclair/typebox";
-
-      type T = Static<typeof T>;
-      const T = Type.Unknown();
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("never", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = never`);
-    const expectedResult = `
-      import { Type, Static } from "@sinclair/typebox";
-
-      type T = Static<typeof T>;
-      const T = Type.Never();
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("null", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = null`);
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Null();
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Array<string>", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(
-      `type T = Array<string>`
-    );
-    const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type T = Static<typeof T>;
-        const T = Type.Array(Type.String());
-        `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("string[]", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string[]`);
-    const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type T = Static<typeof T>;
-        const T = Type.Array(Type.String());
-        `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Union", () => {
+// describe("ts2typebox - Typescript to Typebox", () => {
+//   test("string", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string`);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type T = Static<typeof T>;
+//       const T = Type.String();
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("number", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = number`);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type T = Static<typeof T>;
+//       const T = Type.Number();
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("boolean", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = boolean`);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type T = Static<typeof T>;
+//       const T = Type.Boolean();
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("any", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = any`);
+//     const expectedResult = `
+//       import { Type, Static } from '@sinclair/typebox'
+//
+//       type T = Static<typeof T>
+//       const T = Type.Any()
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("unknown", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = unknown`);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type T = Static<typeof T>;
+//       const T = Type.Unknown();
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("never", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = never`);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type T = Static<typeof T>;
+//       const T = Type.Never();
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("null", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = null`);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Null();
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Array<string>", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(
+//       `type T = Array<string>`
+//     );
+//     const expectedResult = `
+//         import { Type, Static } from "@sinclair/typebox";
+//
+//         type T = Static<typeof T>;
+//         const T = Type.Array(Type.String());
+//         `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("string[]", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`type T = string[]`);
+//     const expectedResult = `
+//         import { Type, Static } from "@sinclair/typebox";
+//
+//         type T = Static<typeof T>;
+//         const T = Type.Array(Type.String());
+//         `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Union", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//       type A = number;
+//       type B = string;
+//
+//       type T = A | B;
+//         `);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type A = Static<typeof A>;
+//       const A = Type.Number();
+//
+//       type B = Static<typeof B>;
+//       const B = Type.String();
+//
+//       type T = Static<typeof T>;
+//       const T = Type.Union([A, B]);`;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Intersect", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//       type T = {
+//         x: number;
+//       } & {
+//         y: string;
+//       };
+//     `);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Intersect([
+//       Type.Object({
+//         x: Type.Number(),
+//       }),
+//       Type.Object({
+//         y: Type.String(),
+//       }),
+//     ]);
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Literal", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//       type T = "a" | "b";
+//       `);
+//     const expectedResult = `
+//       import { Type, Static } from "@sinclair/typebox";
+//
+//       type T = Static<typeof T>;
+//       const T = Type.Union([Type.Literal("a"), Type.Literal("b")]);`;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Object", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//        type T = {
+//          a: number;
+//          b: string;
+//        };
+//       `);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Object({
+//       a: Type.Number(),
+//       b: Type.String(),
+//     });
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Tuple", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//     type T = [number, null];
+//       `);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Tuple([Type.Number(), Type.Null()]);
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Enum", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//     enum A {
+//       A,
+//       B,
+//     }
+//
+//     type T = A;
+//     `);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     enum AEnum {
+//       A,
+//       B,
+//     }
+//
+//     const A = Type.Enum(AEnum);
+//
+//     type T = Static<typeof T>;
+//     const T = A;
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("keyof", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//     type T = keyof {
+//       x: number;
+//       y: string;
+//     };
+//     `);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.KeyOf(
+//       Type.Object({
+//         x: Type.Number(),
+//         y: Type.String(),
+//       })
+//     );
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Record", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(
+//       `type T = Record<string, number>;`
+//     );
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Record(Type.String(), Type.Number());
+//       `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Utility - Partial", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(
+//       `type T = Partial<{ a: 1; b: 2 }>;`
+//     );
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Partial(
+//       Type.Object({
+//         a: Type.Literal(1),
+//         b: Type.Literal(2),
+//       })
+//     );
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Utility - Pick", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(
+//       `type T = Pick<{ a: 1; b: 2 }, "a">;`
+//     );
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Pick(
+//       Type.Object({
+//         a: Type.Literal(1),
+//         b: Type.Literal(2),
+//       }),
+//       Type.Literal("a")
+//     );
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Utility - Omit", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(
+//       `type T = Omit<{ a: 1; b: 2 }, "a">;`
+//     );
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Omit(
+//       Type.Object({
+//         a: Type.Literal(1),
+//         b: Type.Literal(2),
+//       }),
+//       Type.Literal("a")
+//     );
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Utility - Required", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(
+//       `type T = Required<{ a?: 1; b?: 2 }>;`
+//     );
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Required(
+//       Type.Object({
+//         a: Type.Optional(Type.Literal(1)),
+//         b: Type.Optional(Type.Literal(2)),
+//       })
+//     );
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+//   test("Indexed Access", () => {
+//     const generatedTypebox = TypeScriptToTypeBox.Generate(`
+//     type A = {
+//       a: number;
+//     };
+//
+//     type T = A["a"];
+//     `);
+//     const expectedResult = `
+//     import { Type, Static } from "@sinclair/typebox";
+//
+//     type A = Static<typeof A>;
+//     const A = Type.Object({
+//       a: Type.Number(),
+//     });
+//
+//     type T = Static<typeof T>;
+//     const T = Type.Index(A, Type.Literal("a"));
+//     `;
+//     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+//   });
+describe("jsdoc to JSON schema options", () => {
+  test("flat type - number", () => {
     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-      type A = number;
-      type B = string;
-
-      type T = A | B;
-        `);
+      /**
+       * @minimum 100
+       * @maximum 200
+       * @multipleOf 2
+       * @default 150
+       * @description "it's a number" - strings must be quoted
+       * @foobar "should support unknown props"
+       */
+      type T = number;
+      `);
     const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
-      type A = Static<typeof A>;
-      const A = Type.Number();
-
-      type B = Static<typeof B>;
-      const B = Type.String();
-
       type T = Static<typeof T>;
-      const T = Type.Union([A, B]);`;
+      const T = Type.Number({
+          minimum: 100,
+          maximum: 200,
+          multipleOf: 2,
+          default: 150,
+          description: "it's a number",
+          foobar: "should support unknown props",
+      });
+      `;
     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
-  test("Intersect", () => {
+  test("type with properties - number", () => {
     const generatedTypebox = TypeScriptToTypeBox.Generate(`
       type T = {
-        x: number;
-      } & {
-        y: string;
-      };
-    `);
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Intersect([
-      Type.Object({
-        x: Type.Number(),
-      }),
-      Type.Object({
-        y: Type.String(),
-      }),
-    ]);
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Literal", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
-      type T = "a" | "b";
+       /**
+        * @minimum 100
+        * @maximum 200
+        * @multipleOf 2
+        * @default 150
+        * @description "it's a number" - strings must be quoted
+        * @foobar "should support unknown props"
+        */
+        a: number;
+      }
       `);
     const expectedResult = `
       import { Type, Static } from "@sinclair/typebox";
 
       type T = Static<typeof T>;
-      const T = Type.Union([Type.Literal("a"), Type.Literal("b")]);`;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Object", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
-       type T = {
-         a: number;
-         b: string;
-       };
-      `);
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Object({
-      a: Type.Number(),
-      b: Type.String(),
-    });
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Tuple", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
-    type T = [number, null];
-      `);
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Tuple([Type.Number(), Type.Null()]);
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Enum", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
-    enum A {
-      A,
-      B,
-    }
-
-    type T = A;
-    `);
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    enum AEnum {
-      A,
-      B,
-    }
-
-    const A = Type.Enum(AEnum);
-
-    type T = Static<typeof T>;
-    const T = A;
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("keyof", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
-    type T = keyof {
-      x: number;
-      y: string;
-    };
-    `);
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.KeyOf(
-      Type.Object({
-        x: Type.Number(),
-        y: Type.String(),
-      })
-    );
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Record", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(
-      `type T = Record<string, number>;`
-    );
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Record(Type.String(), Type.Number());
+      const T = Type.Object({a: Type.Number({
+          minimum: 100,
+          maximum: 200,
+          multipleOf: 2,
+          default: 150,
+          description: "it's a number",
+          foobar: "should support unknown props",
+      })});
       `;
     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
-  test("Utility - Partial", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(
-      `type T = Partial<{ a: 1; b: 2 }>;`
-    );
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Partial(
-      Type.Object({
-        a: Type.Literal(1),
-        b: Type.Literal(2),
-      })
-    );
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Utility - Pick", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(
-      `type T = Pick<{ a: 1; b: 2 }, "a">;`
-    );
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Pick(
-      Type.Object({
-        a: Type.Literal(1),
-        b: Type.Literal(2),
-      }),
-      Type.Literal("a")
-    );
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Utility - Omit", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(
-      `type T = Omit<{ a: 1; b: 2 }, "a">;`
-    );
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Omit(
-      Type.Object({
-        a: Type.Literal(1),
-        b: Type.Literal(2),
-      }),
-      Type.Literal("a")
-    );
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Utility - Required", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(
-      `type T = Required<{ a?: 1; b?: 2 }>;`
-    );
-    const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
-
-    type T = Static<typeof T>;
-    const T = Type.Required(
-      Type.Object({
-        a: Type.Optional(Type.Literal(1)),
-        b: Type.Optional(Type.Literal(2)),
-      })
-    );
-    `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-  test("Indexed Access", () => {
+  test("type with properties - string", () => {
     const generatedTypebox = TypeScriptToTypeBox.Generate(`
-    type A = {
-      a: number;
-    };
-
-    type T = A["a"];
-    `);
+      type T = {
+       /**
+        * @minimum 100
+        * @maximum 200
+        * @multipleOf 2
+        * @default 150
+        * @description "it's a number" - strings must be quoted
+        * @foobar "should support unknown props"
+        */
+        a: string;
+      }
+      `);
     const expectedResult = `
-    import { Type, Static } from "@sinclair/typebox";
+      import { Type, Static } from "@sinclair/typebox";
 
-    type A = Static<typeof A>;
-    const A = Type.Object({
-      a: Type.Number(),
-    });
-
-    type T = Static<typeof T>;
-    const T = Type.Index(A, Type.Literal("a"));
-    `;
+      type T = Static<typeof T>;
+      const T = Type.Object({a: Type.String({
+          minimum: 100,
+          maximum: 200,
+          multipleOf: 2,
+          default: 150,
+          description: "it's a number",
+          foobar: "should support unknown props",
+      })});
+      `;
     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
-  describe("jsdoc to JSON schema options", () => {
-    test("type", () => {
-      const generatedTypebox = TypeScriptToTypeBox.Generate(`
+  test("type - optional", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type T = {
         /**
-         * @minimum 100
-         * @maximum 200
          * @multipleOf 2
-         * @default 150
-         * @description "it's a number" - strings must be quoted
-         * @foobar "should support unknown props"
          */
-        type T = number;
-        `);
-      const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
+        a?: number;
+      }
+      `);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
 
-        type T = Static<typeof T>;
-        const T = Type.Number({
-            minimum: 100,
-            maximum: 200,
-            multipleOf: 2,
-            default: 150,
-            description: "it's a number",
-            foobar: "should support unknown props",
-        });
-        `;
-      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-    });
-    test("interface", () => {
-      const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        interface T {
-          /**
-           * @minimum 100
-           * @maximum 200
-           * @multipleOf 2
-           * @default 150
-           * @description "it's a number" - strings must be quoted
-           * @foobar "should support unknown props"
-           */
-          x: number;
-        }
-        `);
-      const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-
-        type T = Static<typeof T>;
-        const T = Type.Object({
-          x: Type.Number({
-            minimum: 100,
-            maximum: 200,
-            multipleOf: 2,
-            default: 150,
-            description: "it's a number",
-            foobar: "should support unknown props",
-          }),
-        });
-        `;
-      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-    });
-    test("optional", () => {
-      const generatedTypebox = TypeScriptToTypeBox.Generate(`
-        type T = {
-          /**
-           * @minimum 4
-           */
-          a?: number
-        }
-        `);
-      const expectedResult = `
-        import { Type, Static } from "@sinclair/typebox";
-          export const T = Type.Object({
-          a: Type.Optional(Type.Number({"minimum": 4}))
-          })
-        `;
-      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-    });
-    // TODO: fix with arrays.
-    // test("readonly", () => {
-    //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
-    //     export type T = {
-    //       /**
-    //        * @minimum 4
-    //        */
-    //       a: readonly number[];
-    //     };
-    //     `);
-    //   const expectedResult = `
-    //     import { Type, Static } from "@sinclair/typebox";
-    //
-    //     export type T = Static<typeof T>;
-    //     export const T = Type.Object({
-    //       a: Type.Array(Type.Number({ minimum: 4 })),
-    //     });
-    //   `;
-    //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-    // });
+      type T = Static<typeof T>;
+      const T = Type.Object({
+        a: Type.Optional(Type.Number({ multipleOf: 2 })),
+      });
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
+  test("type - number[]", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type T = {
+        /**
+         * @minItems 2
+         * @maxItems 4
+         */
+        a: number[];
+      }
+      `);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Object({
+        a: Type.Array(Type.Number(), { minItems: 2, maxItems: 4 }),
+      });
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  test("type - number | string", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type T = {
+       /**
+       * @minItems 2
+       * @maxItems 4
+       */
+      a: number | string;
+      }
+      `);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Object({
+        a: Type.Union([Type.Number(), Type.String()], { minItems: 2, maxItems: 4 }),
+      });
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+
+  // TODO: For now Array<number> is unsupported. Seems to be that Array<number>
+  // is treated like it is a "number" instead of Array<number> on the first
+  // look. For now ignore it, perhaps check if something is of type
+  // Numberkeyword if it is wrapped by an Array in typescript to typebox code
+  // (if my assumption is correct :]).
+  // test("type - Array<number>", () => {
+  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+  //     type T = {
+  //       /**
+  //        * @minItems 2
+  //        * @maxItems 4
+  //        */
+  //       a: Array<number>;
+  //     }
+  //     `);
+  //   const expectedResult = `
+  //     import { Type, Static } from "@sinclair/typebox";
+  //
+  //     type T = Static<typeof T>;
+  //     const T = Type.Object({
+  //       a: Type.Array(Type.Number(), { minItems: 2, maxItems: 4 }),
+  //     });
+  //     `;
+  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  // });
+  // test("interface", () => {
+  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+  //       interface T {
+  //         /**
+  //          * @minimum 100
+  //          * @maximum 200
+  //          * @multipleOf 2
+  //          * @default 150
+  //          * @description "it's a number" - strings must be quoted
+  //          * @foobar "should support unknown props"
+  //          */
+  //         x: number;
+  //       }
+  //       `);
+  //   const expectedResult = `
+  //       import { Type, Static } from "@sinclair/typebox";
+  //
+  //       type T = Static<typeof T>;
+  //       const T = Type.Object({
+  //         x: Type.Number({
+  //           minimum: 100,
+  //           maximum: 200,
+  //           multipleOf: 2,
+  //           default: 150,
+  //           description: "it's a number",
+  //           foobar: "should support unknown props",
+  //         }),
+  //       });
+  //       `;
+  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  // });
+  // test("optional", () => {
+  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+  //     type T = {
+  //       /**
+  //        * @minimum 4
+  //        */
+  //       a?: number
+  //     }
+  //     `);
+  //   const expectedResult = `
+  //     import { Type, Static } from "@sinclair/typebox";
+  //       export const T = Type.Object({
+  //       a: Type.Optional(Type.Number({"minimum": 4}))
+  //       })
+  //     `;
+  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  // });
+  // TODO: fix with arrays.
+  // test("readonly", () => {
+  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+  //     export type T = {
+  //       /**
+  //        * @minimum 4
+  //        */
+  //       a: readonly number[];
+  //     };
+  //     `);
+  //   const expectedResult = `
+  //     import { Type, Static } from "@sinclair/typebox";
+  //
+  //     export type T = Static<typeof T>;
+  //     export const T = Type.Object({
+  //       a: Type.Array(Type.Number({ minimum: 4 })),
+  //     });
+  //   `;
+  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  // });
+  // });
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -403,5 +403,42 @@ describe("ts2typebox - Typescript to Typebox", () => {
         `;
       expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
     });
+    test("optional", () => {
+      const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        type T = {
+          /**
+           * @minimum 4
+           */
+          a?: number
+        }
+        `);
+      const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+          export const T = Type.Object({
+          a: Type.Optional(Type.Number({"minimum": 4}))
+          })
+        `;
+      expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    });
+    // TODO: fix with arrays.
+    // test("readonly", () => {
+    //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    //     export type T = {
+    //       /**
+    //        * @minimum 4
+    //        */
+    //       a: readonly number[];
+    //     };
+    //     `);
+    //   const expectedResult = `
+    //     import { Type, Static } from "@sinclair/typebox";
+    //
+    //     export type T = Static<typeof T>;
+    //     export const T = Type.Object({
+    //       a: Type.Array(Type.Number({ minimum: 4 })),
+    //     });
+    //   `;
+    //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+    // });
   });
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -469,27 +469,6 @@ describe("jsdoc to JSON schema options", () => {
       `;
     expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   });
-  test("type - number | string", () => {
-    const generatedTypebox = TypeScriptToTypeBox.Generate(`
-      type T = {
-       /**
-       * @minItems 2
-       * @maxItems 4
-       */
-      a: number | string;
-      }
-      `);
-    const expectedResult = `
-      import { Type, Static } from "@sinclair/typebox";
-
-      type T = Static<typeof T>;
-      const T = Type.Object({
-        a: Type.Union([Type.Number(), Type.String()], { minItems: 2, maxItems: 4 }),
-      });
-      `;
-    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  });
-
   // TODO: For now Array<number> is unsupported. Seems to be that Array<number>
   // is treated like it is a "number" instead of Array<number> on the first
   // look. For now ignore it, perhaps check if something is of type
@@ -515,37 +494,79 @@ describe("jsdoc to JSON schema options", () => {
   //     `;
   //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
   // });
-  // test("interface", () => {
-  //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
-  //       interface T {
-  //         /**
-  //          * @minimum 100
-  //          * @maximum 200
-  //          * @multipleOf 2
-  //          * @default 150
-  //          * @description "it's a number" - strings must be quoted
-  //          * @foobar "should support unknown props"
-  //          */
-  //         x: number;
-  //       }
-  //       `);
-  //   const expectedResult = `
-  //       import { Type, Static } from "@sinclair/typebox";
-  //
-  //       type T = Static<typeof T>;
-  //       const T = Type.Object({
-  //         x: Type.Number({
-  //           minimum: 100,
-  //           maximum: 200,
-  //           multipleOf: 2,
-  //           default: 150,
-  //           description: "it's a number",
-  //           foobar: "should support unknown props",
-  //         }),
-  //       });
-  //       `;
-  //   expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
-  // });
+  test("type - readonly number[]", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+    type T = {
+     /**
+     * @minItems 2
+     * @maxItems 4
+     */
+      a: readonly number[];
+    };
+    `);
+    const expectedResult = `
+    import { Type, Static } from "@sinclair/typebox";
+
+    type T = Static<typeof T>;
+    const T = Type.Object({
+      a: Type.Readonly(Type.Array(Type.Number(), { minItems: 2, maxItems: 4 })),
+    });
+    `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+
+  test("type - number | string", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+      type T = {
+       /**
+       * @minItems 2
+       * @maxItems 4
+       */
+      a: number | string;
+      }
+      `);
+    const expectedResult = `
+      import { Type, Static } from "@sinclair/typebox";
+
+      type T = Static<typeof T>;
+      const T = Type.Object({
+        a: Type.Union([Type.Number(), Type.String()], { minItems: 2, maxItems: 4 }),
+      });
+      `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
+  // TODO: continue here.
+  test("interface", () => {
+    const generatedTypebox = TypeScriptToTypeBox.Generate(`
+        interface T {
+          /**
+           * @minimum 100
+           * @maximum 200
+           * @multipleOf 2
+           * @default 150
+           * @description "it's a number" - strings must be quoted
+           * @foobar "should support unknown props"
+           */
+          x: number;
+        }
+        `);
+    const expectedResult = `
+        import { Type, Static } from "@sinclair/typebox";
+
+        type T = Static<typeof T>;
+        const T = Type.Object({
+          x: Type.Number({
+            minimum: 100,
+            maximum: 200,
+            multipleOf: 2,
+            default: 150,
+            description: "it's a number",
+            foobar: "should support unknown props",
+          }),
+        });
+        `;
+    expectEqualIgnoreFormatting(generatedTypebox, expectedResult);
+  });
   // test("optional", () => {
   //   const generatedTypebox = TypeScriptToTypeBox.Generate(`
   //     type T = {


### PR DESCRIPTION
jsdoc -> typebox/JSON schema fixes.
Fixed problems with readonly and optional types  ad well as union types and arrays. Added tests for each fixed case.

## How to test
- `yarn test`