### PR TITLE
stop using fixed dependency versions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.7.0
+
+- avoid using fixed dependency versions 
+
 # 1.6.0
 
 - use typebox as peer dependency, update to current typebox major 0.32.X

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# 1.7.0
+# 1.6.1
 
 - avoid using fixed dependency versions 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # 1.6.1
 
-- avoid using fixed dependency versions 
+- stop using fixed dependency versions so users of this package can e.g. use the latest typescript version. See https://github.com/xddq/ts2typebox/pull/27 
 
 # 1.6.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2typebox",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Creates TypeBox code from Typescript code",
   "main": "dist/src/index.js",
   "source": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2typebox",
-  "version": "1.7.0",
+  "version": "1.6.1",
   "description": "Creates TypeBox code from Typescript code",
   "main": "dist/src/index.js",
   "source": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -38,20 +38,20 @@
   },
   "homepage": "https://github.com/xddq/ts2typebox#readme",
   "dependencies": {
-    "@sinclair/typebox-codegen": "0.8.6",
-    "cosmiconfig": "8.1.3",
-    "minimist": "1.2.8",
-    "prettier": "2.8.7",
-    "typescript": "5.2.2"
+    "@sinclair/typebox-codegen": "^0.8.6",
+    "cosmiconfig": "^8.1.3",
+    "minimist": "^1.2.8",
+    "prettier": "^2.8.7",
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@sinclair/typebox": "0.32.31",
-    "@types/minimist": "1.2.2",
-    "@types/node": "18.16.0",
-    "@types/prettier": "2.7.2",
-    "@types/shelljs": "0.8.12",
-    "shelljs": "0.8.5",
-    "tsconfig-paths": "4.1.2"
+    "@sinclair/typebox": "^0.32.31",
+    "@types/minimist": "^1.2.2",
+    "@types/node": "^18.16.0",
+    "@types/prettier": "^2.7.2",
+    "@types/shelljs": "^0.8.12",
+    "shelljs": "^0.8.5",
+    "tsconfig-paths": "^4.1.2"
   },
   "peerDependencies": {
     "@sinclair/typebox": "^0.32.31"

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@sinclair/typebox": "^0.32.31",
-    "@types/minimist": "^1.2.2",
-    "@types/node": "^18.16.0",
-    "@types/prettier": "^2.7.2",
-    "@types/shelljs": "^0.8.12",
-    "shelljs": "^0.8.5",
-    "tsconfig-paths": "^4.1.2"
+    "@sinclair/typebox": "0.32.31",
+    "@types/minimist": "1.2.2",
+    "@types/node": "18.16.0",
+    "@types/prettier": "2.7.2",
+    "@types/shelljs": "0.8.12",
+    "shelljs": "0.8.5",
+    "tsconfig-paths": "4.1.2"
   },
   "peerDependencies": {
     "@sinclair/typebox": "^0.32.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,17 +43,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinclair/typebox@npm:0.32.31":
+  version: 0.32.31
+  resolution: "@sinclair/typebox@npm:0.32.31"
+  checksum: 81988aaea8a9d9cffa501e7a1290fb30464b7551330c6e016dc8787a6be97db839bc134bd0d1ae5b35b66da5c3772a6c7626a63dcc9de1503b51b6b0391ac331
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.31.28":
   version: 0.31.28
   resolution: "@sinclair/typebox@npm:0.31.28"
   checksum: 0dd8e11bb608a28f8db6aa6166a354453126249e5bbf4442654ba1c520bd10a55d0beb4cb294f4834a7619efa833a870a31902933a46548bfc24d0e0710576d2
-  languageName: node
-  linkType: hard
-
-"@sinclair/typebox@npm:^0.32.31":
-  version: 0.32.35
-  resolution: "@sinclair/typebox@npm:0.32.35"
-  checksum: 9a5e5697ca5246837696302d9f14bb7139f3f46a039aa1ebed58a4c76c8593753282e64cfd0fb3c6149b35cd09f33ddef948afe85766d8a32da3c6d0a9d49060
   languageName: node
   linkType: hard
 
@@ -74,10 +74,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimist@npm:^1.2.2":
-  version: 1.2.5
-  resolution: "@types/minimist@npm:1.2.5"
-  checksum: 477047b606005058ab0263c4f58097136268007f320003c348794f74adedc3166ffc47c80ec3e94687787f2ab7f4e72c468223946e79892cf0fd9e25e9970a90
+"@types/minimist@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@types/minimist@npm:1.2.2"
+  checksum: b8da83c66eb4aac0440e64674b19564d9d86c80ae273144db9681e5eeff66f238ade9515f5006ffbfa955ceff8b89ad2bd8ec577d7caee74ba101431fb07045d
   languageName: node
   linkType: hard
 
@@ -88,29 +88,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.16.0":
-  version: 18.19.50
-  resolution: "@types/node@npm:18.19.50"
-  dependencies:
-    undici-types: ~5.26.4
-  checksum: 73bdd2b46fb96816a1f7309e1b609f0832a29739c87df7daa729ff497160be143e02cf18486a0112e1981b092358aed3ca0716b532aff93c7e05f7dbb4f7586a
+"@types/node@npm:18.16.0":
+  version: 18.16.0
+  resolution: "@types/node@npm:18.16.0"
+  checksum: 63e0042136663b9e85ce503a4c65406cc6621fdba63ea66c74b4b1364a9aa9bdb57cadcb76696abab177f38a819b0fa6ace9e7f1647dcb990aedb1b4bd01012f
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:^2.7.2":
-  version: 2.7.3
-  resolution: "@types/prettier@npm:2.7.3"
-  checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
+"@types/prettier@npm:2.7.2":
+  version: 2.7.2
+  resolution: "@types/prettier@npm:2.7.2"
+  checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
   languageName: node
   linkType: hard
 
-"@types/shelljs@npm:^0.8.12":
-  version: 0.8.15
-  resolution: "@types/shelljs@npm:0.8.15"
+"@types/shelljs@npm:0.8.12":
+  version: 0.8.12
+  resolution: "@types/shelljs@npm:0.8.12"
   dependencies:
     "@types/glob": ~7.2.0
     "@types/node": "*"
-  checksum: 94939421c6c83d3075e1c56bf940eb3c34567c6b2ac0b553ec81de7f4c7e7cdfc729117d821c22418d64c45fcd4f96a6ec7ae21ed0d7a80e3e9a008672dde35f
+  checksum: ffb47809abef9ee53f900c6b49adb1382d1d78af7f8b50dd474534e3f73127bc4a3849394e4c9de16481cd50203b12464141b4b49d48e88ba6b4c7cc2c85948c
   languageName: node
   linkType: hard
 
@@ -474,7 +472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shelljs@npm:^0.8.5":
+"shelljs@npm:0.8.5":
   version: 0.8.5
   resolution: "shelljs@npm:0.8.5"
   dependencies:
@@ -514,17 +512,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts2typebox@workspace:."
   dependencies:
-    "@sinclair/typebox": ^0.32.31
+    "@sinclair/typebox": 0.32.31
     "@sinclair/typebox-codegen": ^0.8.6
-    "@types/minimist": ^1.2.2
-    "@types/node": ^18.16.0
-    "@types/prettier": ^2.7.2
-    "@types/shelljs": ^0.8.12
+    "@types/minimist": 1.2.2
+    "@types/node": 18.16.0
+    "@types/prettier": 2.7.2
+    "@types/shelljs": 0.8.12
     cosmiconfig: ^8.1.3
     minimist: ^1.2.8
     prettier: ^2.8.7
-    shelljs: ^0.8.5
-    tsconfig-paths: ^4.1.2
+    shelljs: 0.8.5
+    tsconfig-paths: 4.1.2
     typescript: ^5.2.2
   peerDependencies:
     "@sinclair/typebox": ^0.32.31
@@ -534,14 +532,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"tsconfig-paths@npm:^4.1.2":
-  version: 4.2.0
-  resolution: "tsconfig-paths@npm:4.2.0"
+"tsconfig-paths@npm:4.1.2":
+  version: 4.1.2
+  resolution: "tsconfig-paths@npm:4.1.2"
   dependencies:
     json5: ^2.2.2
     minimist: ^1.2.6
     strip-bom: ^3.0.0
-  checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
+  checksum: 3d9151ecea139594e25618717de15769ab9f38f8e6d510ac16e592b23e7f7105ea13cec5694c3de7e132c98277b775e18edd1651964164ee6d75737c408494cc
   languageName: node
   linkType: hard
 
@@ -582,13 +580,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,28 +32,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinclair/typebox-codegen@npm:0.8.6":
-  version: 0.8.6
-  resolution: "@sinclair/typebox-codegen@npm:0.8.6"
+"@sinclair/typebox-codegen@npm:^0.8.6":
+  version: 0.8.13
+  resolution: "@sinclair/typebox-codegen@npm:0.8.13"
   dependencies:
-    "@sinclair/typebox": ^0.31.0
+    "@sinclair/typebox": ^0.31.28
     prettier: ^2.8.7
     typescript: ^5.1.6
-  checksum: e380d191b2165e81d60eab30479a1fd4ff7ba779d3fc2375db6682a70e286eaf56778abcf5fe2e07496d337cf4ad84c9c2783079c5aabeb0d0bf6144b3ef061a
+  checksum: 5102ed703e1917acf2ccadcb2de7db593294eb24065592f16914769bda17fbaba1feb41dfd042db0b65aa293299ecdafd9e7f67344bafca01d190c0914f276ce
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:0.32.31":
-  version: 0.32.31
-  resolution: "@sinclair/typebox@npm:0.32.31"
-  checksum: 81988aaea8a9d9cffa501e7a1290fb30464b7551330c6e016dc8787a6be97db839bc134bd0d1ae5b35b66da5c3772a6c7626a63dcc9de1503b51b6b0391ac331
+"@sinclair/typebox@npm:^0.31.28":
+  version: 0.31.28
+  resolution: "@sinclair/typebox@npm:0.31.28"
+  checksum: 0dd8e11bb608a28f8db6aa6166a354453126249e5bbf4442654ba1c520bd10a55d0beb4cb294f4834a7619efa833a870a31902933a46548bfc24d0e0710576d2
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:^0.31.0":
-  version: 0.31.3
-  resolution: "@sinclair/typebox@npm:0.31.3"
-  checksum: 8cd8187f6e1568255616d6a721022d6dfefa92fd7d8ff3a2f0b22adfe63ded8458f4c504e8e98c25f63cd148a62b248589eef02a63e360687d3b69bca222fc3d
+"@sinclair/typebox@npm:^0.32.31":
+  version: 0.32.35
+  resolution: "@sinclair/typebox@npm:0.32.35"
+  checksum: 9a5e5697ca5246837696302d9f14bb7139f3f46a039aa1ebed58a4c76c8593753282e64cfd0fb3c6149b35cd09f33ddef948afe85766d8a32da3c6d0a9d49060
   languageName: node
   linkType: hard
 
@@ -74,10 +74,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimist@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@types/minimist@npm:1.2.2"
-  checksum: b8da83c66eb4aac0440e64674b19564d9d86c80ae273144db9681e5eeff66f238ade9515f5006ffbfa955ceff8b89ad2bd8ec577d7caee74ba101431fb07045d
+"@types/minimist@npm:^1.2.2":
+  version: 1.2.5
+  resolution: "@types/minimist@npm:1.2.5"
+  checksum: 477047b606005058ab0263c4f58097136268007f320003c348794f74adedc3166ffc47c80ec3e94687787f2ab7f4e72c468223946e79892cf0fd9e25e9970a90
   languageName: node
   linkType: hard
 
@@ -88,27 +88,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.16.0":
-  version: 18.16.0
-  resolution: "@types/node@npm:18.16.0"
-  checksum: 63e0042136663b9e85ce503a4c65406cc6621fdba63ea66c74b4b1364a9aa9bdb57cadcb76696abab177f38a819b0fa6ace9e7f1647dcb990aedb1b4bd01012f
+"@types/node@npm:^18.16.0":
+  version: 18.19.50
+  resolution: "@types/node@npm:18.19.50"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 73bdd2b46fb96816a1f7309e1b609f0832a29739c87df7daa729ff497160be143e02cf18486a0112e1981b092358aed3ca0716b532aff93c7e05f7dbb4f7586a
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:2.7.2":
-  version: 2.7.2
-  resolution: "@types/prettier@npm:2.7.2"
-  checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
+"@types/prettier@npm:^2.7.2":
+  version: 2.7.3
+  resolution: "@types/prettier@npm:2.7.3"
+  checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
   languageName: node
   linkType: hard
 
-"@types/shelljs@npm:0.8.12":
-  version: 0.8.12
-  resolution: "@types/shelljs@npm:0.8.12"
+"@types/shelljs@npm:^0.8.12":
+  version: 0.8.15
+  resolution: "@types/shelljs@npm:0.8.15"
   dependencies:
     "@types/glob": ~7.2.0
     "@types/node": "*"
-  checksum: ffb47809abef9ee53f900c6b49adb1382d1d78af7f8b50dd474534e3f73127bc4a3849394e4c9de16481cd50203b12464141b4b49d48e88ba6b4c7cc2c85948c
+  checksum: 94939421c6c83d3075e1c56bf940eb3c34567c6b2ac0b553ec81de7f4c7e7cdfc729117d821c22418d64c45fcd4f96a6ec7ae21ed0d7a80e3e9a008672dde35f
   languageName: node
   linkType: hard
 
@@ -186,15 +188,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:8.1.3":
-  version: 8.1.3
-  resolution: "cosmiconfig@npm:8.1.3"
+"cosmiconfig@npm:^8.1.3":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
-    import-fresh: ^3.2.1
+    import-fresh: ^3.3.0
     js-yaml: ^4.1.0
-    parse-json: ^5.0.0
+    parse-json: ^5.2.0
     path-type: ^4.0.0
-  checksum: b3d277bc3a8a9e649bf4c3fc9740f4c52bf07387481302aa79839f595045368903bf26ea24a8f7f7b8b180bf46037b027c5cb63b1391ab099f3f78814a147b2b
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: dc339ebea427898c9e03bf01b56ba7afbac07fc7d2a2d5a15d6e9c14de98275a9565da949375aee1809591c152c0a3877bb86dbeaf74d5bd5aaa79955ad9e7a0
   languageName: node
   linkType: hard
 
@@ -258,7 +265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -358,7 +365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:1.2.8, minimist@npm:^1.2.6":
+"minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -383,7 +390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^5.0.0":
+"parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
   dependencies:
@@ -413,15 +420,6 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
-  languageName: node
-  linkType: hard
-
-"prettier@npm:2.8.7":
-  version: 2.8.7
-  resolution: "prettier@npm:2.8.7"
-  bin:
-    prettier: bin-prettier.js
-  checksum: fdc8f2616f099f5f0d685907f4449a70595a0fc1d081a88919604375989e0d5e9168d6121d8cc6861f21990b31665828e00472544d785d5940ea08a17660c3a6
   languageName: node
   linkType: hard
 
@@ -476,7 +474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shelljs@npm:0.8.5":
+"shelljs@npm:^0.8.5":
   version: 0.8.5
   resolution: "shelljs@npm:0.8.5"
   dependencies:
@@ -516,18 +514,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ts2typebox@workspace:."
   dependencies:
-    "@sinclair/typebox": 0.32.31
-    "@sinclair/typebox-codegen": 0.8.6
-    "@types/minimist": 1.2.2
-    "@types/node": 18.16.0
-    "@types/prettier": 2.7.2
-    "@types/shelljs": 0.8.12
-    cosmiconfig: 8.1.3
-    minimist: 1.2.8
-    prettier: 2.8.7
-    shelljs: 0.8.5
-    tsconfig-paths: 4.1.2
-    typescript: 5.2.2
+    "@sinclair/typebox": ^0.32.31
+    "@sinclair/typebox-codegen": ^0.8.6
+    "@types/minimist": ^1.2.2
+    "@types/node": ^18.16.0
+    "@types/prettier": ^2.7.2
+    "@types/shelljs": ^0.8.12
+    cosmiconfig: ^8.1.3
+    minimist: ^1.2.8
+    prettier: ^2.8.7
+    shelljs: ^0.8.5
+    tsconfig-paths: ^4.1.2
+    typescript: ^5.2.2
   peerDependencies:
     "@sinclair/typebox": ^0.32.31
   bin:
@@ -536,18 +534,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"tsconfig-paths@npm:4.1.2":
-  version: 4.1.2
-  resolution: "tsconfig-paths@npm:4.1.2"
+"tsconfig-paths@npm:^4.1.2":
+  version: 4.2.0
+  resolution: "tsconfig-paths@npm:4.2.0"
   dependencies:
     json5: ^2.2.2
     minimist: ^1.2.6
     strip-bom: ^3.0.0
-  checksum: 3d9151ecea139594e25618717de15769ab9f38f8e6d510ac16e592b23e7f7105ea13cec5694c3de7e132c98277b775e18edd1651964164ee6d75737c408494cc
+  checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
   languageName: node
   linkType: hard
 
-"typescript@npm:5.2.2, typescript@npm:^5.1.6":
+"typescript@npm:^5.1.6":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
   bin:
@@ -557,13 +555,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.1.6#~builtin<compat/typescript>":
+"typescript@npm:^5.2.2":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b309040f3a1cd91c68a5a58af6b9fdd4e849b8c42d837b2c2e73f9a4f96a98c4f1ed398a9aab576ee0a4748f5690cf594e6b99dbe61de7839da748c41e6d6ca8
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.1.6#~builtin<compat/typescript>":
   version: 5.2.2
   resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=77c9e2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=77c9e2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I'm currently getting issues when pulling ts2typebox in as a dependency to another project because it has a fixed dependency on Typescript 5.2.2.

This PR makes it avoid using fixed dependency versions so that there will be fewer compatibility issues.